### PR TITLE
refactor: update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,38 +1,41 @@
+### Site metadata ###
+
 name: Junaid Farooq
 title: Junaid Farooq
 description: Ruby, Elixir, DevOps
 meta_description: "Ruby, Elixir, DevOps"
 
+### Build settings ###
+
+url: "https://ijunaidfarooq.com"
+baseurl: ""
+
+permalink: /:year/:title/
+
 aboutPage: true
-github: [metadata]
 
-markdown: kramdown
-highlighter: rouge
-livereload: true
+github:
+  - metadata
 
-plugins: [jekyll-paginate]
+plugins:
+  - jekyll-paginate
+  
 paginate: 20
-baseurl: /
-domain_name: 'https://ijunaidfarooq.com/'
 
-permalink:       /:year/:title/
-
+# Reminder that empty string matches all files.
 defaults:
-    -
-        scope:
-            path: "" # empty string for all files
-            type: pages
-        values:
-            layout: default
-    -
-        scope:
-            path: "" # empty string for all files
-            type: posts
-        values:
-            layout: post
-    -
-        scope:
-            path: ""
-            type: drafts
-        values:
-            layout: post
+  - scope:
+      path: "" 
+      type: posts
+    values:
+      layout: post
+  - scope:
+      path: ""
+      type: drafts
+    values:
+      layout: post
+  - scope:
+      path: "" 
+      type: pages
+    values:
+      layout: default


### PR DESCRIPTION
I remove rouge and kramdown as those are Jekyll defaults https://michaelcurrin.github.io/dev-cheatsheets/cheatsheets/jekyll/configuration/default-values.html

I made lists like plugins easier to view and edit.

Removed livereload - rather control that by Makefile as is already done.

And some other style changes.

---

I replaced domain with the Jekyll standard URL.

This doesn't matter for both things.

But if you do make a sitemap or RSS feed or robots file then an absolute URL is required.

For example, a robots file can point to a sitemap like this
```
{{ 'sitemap.xml' | absolute_url }}
```

And that becomes

```
https://ijunaidfarooq.com/sitemap.xml
```

But only if you do a Prod build.

```
build:
	JEKYLL_ENV=production bundle exec jekyll build --trace
```