### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
-_site/
-.sass-cache/
 .DS_Store
+
+.sass-cache/
+
+vendor/
+.bundle
+
+_site/


### PR DESCRIPTION
Allow use of bundle to install a `vendor` directory and add `.bundle/config` and ignore them.