### PR TITLE
build: update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,23 @@
-all: help
+default: help
+
+all: install build
+
+
+help: ## Show the commands and help
+	@grep -E '^[a-zA-Z_ -]+:' $(MAKEFILE_LIST) \
+		| sort \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 
 install: ## Install dependencies
 	which ruby || asdf install
 	which bundle || gem install bundler
+
+	bundle config set --local path vendor/bundle
 	bundle install
 
-start: ## Start development server at port 4444
+s start: ## Start development server at port 4444
 	bundle exec jekyll server --livereload --watch --future --port 4444
 
-help:
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+build: ## Production build
+	JEKYLL_ENV=production bundle exec jekyll build --trace


### PR DESCRIPTION
I made `default` the default instead of all.

```sh
$ make
```

OR

```sh
make help
```

---

And `all` now installs and builds (useful before you push to make sure it all works including Gemfile changs).

```sh
make all --dry-run
```

```
which ruby || asdf install
which bundle || gem install bundler
bundle config set --local path vendor/bundle
bundle install
JEKYLL_ENV=production bundle exec jekyll build --trace
```
---

I added an alias so you can do this for start:

```sh
make s
```

OR

```sh
make start
```

---

I updated help regex to pick allow spaces in a target like `s start`. And also I removed requirement for `##` to exist so that targets _without_ comments still show up.

Help result:

<img width="668" alt="Screen Shot 2021-06-21 at 12 06 50 pm" src="https://user-images.githubusercontent.com/18750745/122745415-441c7400-d289-11eb-9f2c-9263258b1206.png">
